### PR TITLE
fix: added receiver to claimLockFees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -417,3 +417,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `AmmImpl.createPermissionlessConstantProductPoolWithConfig` to create constant product pool based on `config` account.
 - `AmmImpl.getFeeConfigurations` to get all fee configurations to be used in `AmmImpl.createPermissionlessConstantProductPoolWithConfig`
+
+## dynamic-amm [1.3.5] - PR #215
+
+### Changed
+
+- `AmmImpl.claimLockFee` to include `receiver` and `payer` parameters to indicate the receiver and payer of the fees.

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meteora-ag/dynamic-amm-sdk",
-  "version": "1.3.4-rc.0",
+  "version": "1.3.5",
   "description": "Meteora Dynamic Amm SDK is a typescript library that allows you to interact with Meteora's AMM.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/ts-client/package.json
+++ b/ts-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meteora-ag/dynamic-amm-sdk",
-  "version": "1.3.4",
+  "version": "1.3.4-rc.0",
   "description": "Meteora Dynamic Amm SDK is a typescript library that allows you to interact with Meteora's AMM.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
### Context
Believe created pools with an account owned by Token Program. Because it is owned by Token Program, they can't collect fees from it. They can still sign with this account, but not transfer out.

### Solution
Add an optional receiver to the claimLockFee function so that they can sign with the owner and payer + indicate a receiver of the fees.